### PR TITLE
Fix API boilerplate (appsettings.json)

### DIFF
--- a/Source/Boilerplate.Templates/Content/ApiTemplate/appsettings.json
+++ b/Source/Boilerplate.Templates/Content/ApiTemplate/appsettings.json
@@ -35,9 +35,9 @@
         }
       }
       //#else
-      //"Http": {
-      //  "Url": "http://localhost:5000"
-      //}
+      "Http": {
+        "Url": "http://localhost:5000"
+      }
       //#endif
     }
   },


### PR DESCRIPTION
If the user specifies 'HttpsEverywhere' with value 'false' and immediately starts the project, then in the 'KestrelOptions', the EndPoints field is null, so we get the 'object reference not set to an instance of an object' (KestrelServerOptionsExtensions.ConfigureEndpoints)